### PR TITLE
Corrects async publish due to shared use of producer

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -53,7 +53,7 @@ func (c *client) Publish(
 			}
 			return nil
 		})
-		return nil
+		return ErrState
 	}
 	publisher.SendAsync(ctx,
 		&pulsar.ProducerMessage{

--- a/subscribe.go
+++ b/subscribe.go
@@ -18,7 +18,7 @@ func (c *client) Subscribe(
 	topic string,
 	// A regular expression to subscribe to multiple topics under the same namespace
 	topicsPattern string,
-	// Subscription type, can be "exclusive", "shared", "failover" or "keyshared" (defaults to "keyshared")
+	// Subscription type, can be "Exclusive", "Shared", "Failover" or "Key_Shared" (defaults to "Key_Shared")
 	subscriptionType string,
 	// Initial position of the cursor, can be "earliest" or "latest" (defaults to "latest")
 	initialPosition string,
@@ -221,7 +221,7 @@ func stringToSubscriptionType(s string) pulsar.SubscriptionType {
 		return pulsar.Shared
 	case "failover":
 		return pulsar.Failover
-	case "keyshared":
+	case "key_shared":
 		return pulsar.KeyShared
 	default:
 		// If the string doesn't match any known constant, return pulsar.KeyShared value

--- a/subscribe_ext.go
+++ b/subscribe_ext.go
@@ -13,7 +13,7 @@ func (c *client) SubscribeForDuration(
 	topic string,
 	// A regular expression to subscribe to multiple topics under the same namespace
 	topicsPattern string,
-	// Subscription type, can be "exclusive", "shared", "failover" or "keyshared" (defaults to "keyshared")
+	// Subscription type, can be "Exclusive", "Shared", "Failover" or "Key_Shared" (defaults to "Key_Shared")
 	subscriptionType string,
 	// Initial position of the cursor, can be "earliest" or "latest" (defaults to "latest")
 	initialPosition string,


### PR DESCRIPTION
We reuse the same publisher when publishing to the same topic, so spawning a thread each time we call publish can run in to two threads attempting to use the same publisher at the same time.

Also small improvement to the subscription types to match the usual way they are referenced in doc. 